### PR TITLE
fix: myFetch function parameter names

### DIFF
--- a/src/helpers/myFetch.js
+++ b/src/helpers/myFetch.js
@@ -24,7 +24,7 @@ async function makeRequest(url, type, body) {
   }
 }
 
-export default async function myFetch(type, body, url) {
-  await makeRequest(type, body, url);
+export default async function myFetch(url, type, body) {
+  await makeRequest(url, type, body);
   return { response, error };
 }


### PR DESCRIPTION
Hello! It seems to me that the order of the parameters was messed up, because myFetch actually takes (url, type, body) (for example myFetch("login", "POST", body) in auth.js).
This is a minor detail, but it made me a little confused :) thanks!